### PR TITLE
[FIXED JENKINS-22368] Discovery fails behind proxy

### DIFF
--- a/src/main/java/hudson/plugins/openid/GoogleAppSsoSecurityRealm.java
+++ b/src/main/java/hudson/plugins/openid/GoogleAppSsoSecurityRealm.java
@@ -37,15 +37,7 @@ public class GoogleAppSsoSecurityRealm extends OpenIdSsoSecurityRealm {
 
     @Override
     protected ConsumerManager createManager() throws ConsumerException {
-        final Hudson instance = Hudson.getInstance();
-        if (instance.proxy != null) {
-            ProxyProperties props = new ProxyProperties();
-            props.setProxyHostName(instance.proxy.name);
-            props.setProxyPort(instance.proxy.port);
-            props.setUserName(instance.proxy.getUserName());
-            props.setProxyHostName(instance.proxy.getPassword());
-            HttpClientFactory.setProxyProperties(props);
-        }
+        addProxyPropertiesToHttpClient();
         ConsumerManager m = new ConsumerManager();
         m.setDiscovery(new Discovery() {
             /**


### PR DESCRIPTION
This commit addresses the problem described in [FIXED JENKINS-22368] and
may also correct [JENKINS-11753]. Proxy settings in openid4java's
HttpClientFactory will now be initialized when calling the constructor of
the OpenIdSsoSecurityRealm & GoogleAppSsoSecurityRealm classes in addition
to the existing call in the commenceLogin process.
