### PR TITLE
[JENKINS-23009] Add Support for 3 different email attributes for AX Extension

### DIFF
--- a/src/main/java/hudson/plugins/openid/impl/UserInfoExtension.java
+++ b/src/main/java/hudson/plugins/openid/impl/UserInfoExtension.java
@@ -41,16 +41,20 @@ import org.openid4java.message.sreg.SRegResponse;
  */
 @Extension
 public class UserInfoExtension extends OpenIdExtension {
-	
-	@Override 
-	public void extendFetch(FetchRequest fetch) throws MessageException {
-		fetch.addAttribute("email", "http://schema.openid.net/contact/email", true);
-	    fetch.addAttribute("firstName", "http://axschema.org/namePerson/first", true);
-	    fetch.addAttribute("lastName", "http://axschema.org/namePerson/last", true);
-	    fetch.addAttribute("ff", "http://axschema.org/namePerson", false);
-	    fetch.addAttribute("img", "http://axschema.org/media/image/default/", false);
-	}
-	
+    
+    @Override 
+    public void extendFetch(FetchRequest fetch) throws MessageException {
+        // AX is standardized, but OPs support multiple different Email parameters.
+        // see http://blog.nerdbank.net/2009/03/how-to-pretty-much-guarantee-that-you.html
+        fetch.addAttribute("email", "http://axschema.org/contact/email", true);
+        fetch.addAttribute("email2", "http://schema.openid.net/contact/email", true);
+        fetch.addAttribute("email3", "http://openid.net/schema/contact/email", true);
+        fetch.addAttribute("firstName", "http://axschema.org/namePerson/first", true);
+        fetch.addAttribute("lastName", "http://axschema.org/namePerson/last", true);
+        fetch.addAttribute("ff", "http://axschema.org/namePerson", false);
+        fetch.addAttribute("img", "http://axschema.org/media/image/default/", false);
+    }
+    
     @Override
     public void extend(AuthRequest authRequest) throws MessageException {
         // extend some user information
@@ -80,6 +84,10 @@ public class UserInfoExtension extends OpenIdExtension {
                 }
                 if (email==null)
                     email = fr.getAttributeValue("email");
+                if (email==null)
+                    email = fr.getAttributeValue("email2");
+                if (email==null)
+                    email = fr.getAttributeValue("email3");
             }
         } catch (MessageException e) {
             // if the process doesn't contain AX information, ignore. Maybe this is a bug in openid4java?

--- a/src/test/java/hudson/plugins/openid/OpenIdAXEmailAttributesTest.java
+++ b/src/test/java/hudson/plugins/openid/OpenIdAXEmailAttributesTest.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.openid;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import hudson.model.User;
+import hudson.plugins.openid.OpenIdTestService.IdProperty;
+import hudson.tasks.Mailer;
+import hudson.tasks.Mailer.UserProperty;
+
+import java.util.Map;
+
+import static hudson.plugins.openid.OpenIdTestService.*;
+
+/**
+ * @author Nirmal Jonnalagedda
+ */
+public class OpenIdAXEmailAttributesTest extends OpenIdTestCase {
+
+    void _testEmailAttributes(String userName) throws Exception {
+        WebClient wc = new WebClient();
+
+        OpenIdSsoSecurityRealm realm = new OpenIdSsoSecurityRealm(openid.url);
+        hudson.setSecurityRealm(realm);
+
+        HtmlPage top = wc.goTo("");
+        top = top.getAnchorByText("log in").click();
+        
+        User u = User.get(userName);
+        UserProperty up = u.getProperty(Mailer.UserProperty.class);
+        
+        assertTrue(up.hasExplicitlyConfiguredAddress());
+        
+        if (openid.props.get(IdProperty.email) != null)
+            assertEquals(up.getAddress(), openid.props.get(IdProperty.email));
+        else if (openid.props.get(IdProperty.email2) != null)
+            assertEquals(up.getAddress(), openid.props.get(IdProperty.email2));
+        else
+            assertEquals(up.getAddress(), openid.props.get(IdProperty.email3));
+    }
+
+    public void testEmailWithAXExtensionWithAllSameEmailAttributes() throws Exception {
+        openid = new OpenIdTestService(
+                getServiceUrl(),
+                getPropsAllSameEmails(),
+                Sets.newHashSet("foo", "bar"),
+                Lists.newArrayList(SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+        
+        _testEmailAttributes(openid.props.get(IdProperty.nick));
+    }
+    
+    public void testEmailWithAXExtensionWithAllDifferentEmailAttributes() throws Exception {
+        openid = new OpenIdTestService(
+                getServiceUrl(),
+                getPropsAllDifferentEmails(),
+                Sets.newHashSet("foo", "bar"),
+                Lists.newArrayList(SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+
+        _testEmailAttributes(openid.props.get(IdProperty.nick));
+    }
+    
+    public void testEmailWithAXExtensionWithAnyTwoDifferentEmailAttributes() throws Exception {
+        openid = new OpenIdTestService(
+                getServiceUrl(),
+                getPropsWithAnyTwoDifferentEmails(),
+                Sets.newHashSet("foo", "bar"),
+                Lists.newArrayList(SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+
+        _testEmailAttributes(openid.props.get(IdProperty.nick));
+    }
+    
+    public void testEmailWithAXExtensionWithAnyTwoSameEmailAttributes() throws Exception {
+        openid = new OpenIdTestService(
+                getServiceUrl(),
+                getPropsWithAnyTwoSameEmails(),
+                Sets.newHashSet("foo", "bar"),
+                Lists.newArrayList(SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+
+        _testEmailAttributes(openid.props.get(IdProperty.nick));
+    }
+    
+    public void testEmailWithAXExtensionWithOneEmailAttribute() throws Exception {
+        openid = new OpenIdTestService(
+                getServiceUrl(),
+                getPropsWithOneEmail(),
+                Sets.newHashSet("foo", "bar"),
+                Lists.newArrayList(SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+
+        _testEmailAttributes(openid.props.get(IdProperty.nick));
+    }
+}

--- a/src/test/java/hudson/plugins/openid/OpenIdTestCase.java
+++ b/src/test/java/hudson/plugins/openid/OpenIdTestCase.java
@@ -51,6 +51,45 @@ public abstract class OpenIdTestCase extends HudsonTestCase implements Unprotect
         return getURL().toExternalForm() + getUrlName() + "/openid/";
     }
 
+    Map<IdProperty,String> getPropsAllDifferentEmails() {
+        Map<IdProperty,String> props = getProps();
+        props.remove(IdProperty.email);
+        props.put(IdProperty.email, "alice.wonder@Net");
+        props.put(IdProperty.email2, "alice@Net");
+        props.put(IdProperty.email3, "alice.wonderland@Net");
+        return props;
+    }
+    
+    Map<IdProperty,String> getPropsAllSameEmails() {
+        Map<IdProperty,String> props = getProps();
+        props.put(IdProperty.email2, "alice@Net");
+        props.put(IdProperty.email3, "alice@Net");
+        return props;
+    }
+    
+    Map<IdProperty,String> getPropsWithAnyTwoDifferentEmails() {
+        Map<IdProperty,String> props = getProps();
+        props.remove(IdProperty.email);
+        props.put(IdProperty.email2, "alice.Wonderland@Net");
+        props.put(IdProperty.email3, "alice@Net");
+        return props;
+    }
+    
+    Map<IdProperty,String> getPropsWithAnyTwoSameEmails() {
+        Map<IdProperty,String> props = getProps();
+        props.remove(IdProperty.email);
+        props.put(IdProperty.email, "alice.wonder@Net");
+        props.put(IdProperty.email3, "alice@Net");
+        return props;
+    }
+    
+    Map<IdProperty,String> getPropsWithOneEmail() {
+        Map<IdProperty,String> props = getProps();
+        props.remove(IdProperty.email);
+        props.put(IdProperty.email2, "alice.Wonderland@Net");
+        return props;
+    }
+
     Map<IdProperty,String> getProps() {
         Map<IdProperty,String> props = Maps.newEnumMap(IdProperty.class);
         props.put(IdProperty.email, "alice@Net");

--- a/src/test/java/hudson/plugins/openid/OpenIdTestService.java
+++ b/src/test/java/hudson/plugins/openid/OpenIdTestService.java
@@ -97,7 +97,7 @@ public class OpenIdTestService {
     private final List<ProcessExtension> extensions;
 
     public enum IdProperty {
-        email, nick, fullName, firstName, lastName, derivedFullName
+        email, email2, email3, nick, fullName, firstName, lastName, derivedFullName
     }
 
 
@@ -116,7 +116,14 @@ public class OpenIdTestService {
     }
 
     public String getUserIdentity() {
-        return url + props.get(IdProperty.email);
+        final String email;
+        if (props.get(IdProperty.email) != null)
+            email = props.get(IdProperty.email);
+        else if (props.get(IdProperty.email2) != null)
+            email = props.get(IdProperty.email2);
+        else
+            email = props.get(IdProperty.email3);
+        return url + email;
     }
     
     public HttpResponse doEndpoint(StaplerRequest request) throws IOException {
@@ -224,9 +231,21 @@ public class OpenIdTestService {
                     FetchResponse fr = FetchResponse.createFetchResponse();
 
                     for (Map.Entry<String,String> e : ((Map<String,String>)fetchReq.getAttributes()).entrySet()) {
-                        if ((e.getValue().equals("http://axschema.org/contact/email")
-                        ||  e.getValue().equals("http://schema.openid.net/contact/email")) && s.props.containsKey(IdProperty.email))
-                            fr.addAttribute(e.getKey(),e.getValue(),s.props.get(IdProperty.email));
+                        if ((e.getValue().equals("http://axschema.org/contact/email")) && s.props.containsKey(IdProperty.email)) {
+                            if (s.props.get(IdProperty.email) != null) {
+                                fr.addAttribute(e.getKey(),e.getValue(),s.props.get(IdProperty.email));
+                            }
+                        }
+                        else if ((e.getValue().equals("http://schema.openid.net/contact/email")) && s.props.containsKey(IdProperty.email2)) {
+                            if (s.props.get(IdProperty.email2) != null) {
+                                fr.addAttribute(e.getKey(),e.getValue(),s.props.get(IdProperty.email2));
+                            }
+                        }
+                        else if ((e.getValue().equals("http://openid.net/schema/contact/email")) && s.props.containsKey(IdProperty.email3)) {
+                            if (s.props.get(IdProperty.email3) != null) {
+                                fr.addAttribute(e.getKey(),e.getValue(),s.props.get(IdProperty.email3));
+                            }
+                        }
 
                         if (e.getValue().equals("http://axschema.org/namePerson/first") && s.props.containsKey(IdProperty.firstName))
                             fr.addAttribute(e.getKey(),e.getValue(),s.props.get(IdProperty.firstName));


### PR DESCRIPTION
The standard email attribute type URI for the AX extension is "http://axschema.org/contact/email". However, many of the OpenId providers do not support this standard attribute type URI but instead support one of the following:

```
http://schema.openid.net/contact/email
http://openid.net/schema/contact/email
```

The Jenkins openid-plugin currently supports only "http://schema.openid.net/contact/email". For a better user experience, it is recommended to ask/support all three email attributes.

Corresponding ISSUE logged for this commit: https://issues.jenkins-ci.org/browse/JENKINS-23009
