### PR TITLE
fix test failure

### DIFF
--- a/src/main/java/hudson/plugins/openid/GoogleAppSsoSecurityRealm.java
+++ b/src/main/java/hudson/plugins/openid/GoogleAppSsoSecurityRealm.java
@@ -41,7 +41,6 @@ public class GoogleAppSsoSecurityRealm extends OpenIdSsoSecurityRealm {
 
     @Override
     protected ConsumerManager createManager() throws ConsumerException {
-        addProxyPropertiesToHttpClient();
         HttpFetcherFactory fetcherFactory = new HttpFetcherFactory();
         YadisResolver2 resolver = new YadisResolver2(fetcherFactory);
         ConsumerManager m = new ConsumerManager(new RealmVerifierFactory(resolver), new Discovery(), fetcherFactory);

--- a/src/main/java/hudson/plugins/openid/OpenIdSsoSecurityRealm.java
+++ b/src/main/java/hudson/plugins/openid/OpenIdSsoSecurityRealm.java
@@ -83,6 +83,7 @@ public class OpenIdSsoSecurityRealm extends SecurityRealm {
     @DataBoundConstructor
     public OpenIdSsoSecurityRealm(String endpoint) throws IOException, OpenIDException {
         this.endpoint = endpoint;
+        addProxyPropertiesToHttpClient();
         getDiscoveredEndpoint();
     }
 
@@ -102,7 +103,6 @@ public class OpenIdSsoSecurityRealm extends SecurityRealm {
     }
 
     protected ConsumerManager createManager() throws ConsumerException {
-        addProxyPropertiesToHttpClient();
         HttpFetcherFactory fetcherFactory = new HttpFetcherFactory();
         YadisResolver2 resolver = new YadisResolver2(fetcherFactory);
         ConsumerManager manager = new ConsumerManager(new RealmVerifierFactory(resolver), new Discovery(), fetcherFactory);

--- a/src/test/java/hudson/plugins/openid/OpenIdSsoSecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/openid/OpenIdSsoSecurityRealmTest.java
@@ -175,11 +175,16 @@ public class OpenIdSsoSecurityRealmTest extends OpenIdTestCase {
 		openid = new OpenIdTestService(getServiceUrl(), getProps(),
 				Sets.newHashSet("foo", "bar"), Lists.newArrayList(
 						SREG_EXTENSION, AX_EXTENSION, TEAM_EXTENSION));
+        hudson.proxy = new ProxyConfiguration(FAKE_PROXY_NAME,
+                FAKE_JENKINS_PROXY_PORT);
 
-		OpenIdSsoSecurityRealm realm = new OpenIdSsoSecurityRealm(openid.url);
-		hudson.proxy = new ProxyConfiguration(FAKE_PROXY_NAME,
-				FAKE_JENKINS_PROXY_PORT);
-		realm.createManager();
+        try {
+            OpenIdSsoSecurityRealm realm = new OpenIdSsoSecurityRealm(openid.url);
+            realm.createManager();
+        } catch (DiscoveryException e) {
+            // This is expected since the proxy is fake. Hence, discovery will
+            // not be possible
+        }
 
 		assertEquals(FAKE_PROXY_NAME, HttpClientFactory.getProxyProperties()
 				.getProxyHostName());


### PR DESCRIPTION
http proxy must be configured before Endpoint discovery occurs
