### PR TITLE
[JENKINS-36709] Register correct user id in SecurityContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509</version>
+    <version>1.580.1</version>
   </parent>
 
   <artifactId>openid</artifactId>
@@ -16,6 +16,7 @@
     <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
     <!--TODO: Enforce when the code becomes 100% clean-->
     <findbugs.failOnError>false</findbugs.failOnError>
+    <concurrency>1</concurrency>
   </properties>
 
   <url>http://wiki.jenkins-ci.org/display/JENKINS/OpenID+Plugin</url>

--- a/src/main/java/hudson/plugins/openid/OpenIdSsoSecurityRealm.java
+++ b/src/main/java/hudson/plugins/openid/OpenIdSsoSecurityRealm.java
@@ -174,17 +174,18 @@ public class OpenIdSsoSecurityRealm extends SecurityRealm {
         return new OpenIdSession(getManager(),endpoint,"securityRealm/finishLogin") {
             @Override
             protected HttpResponse onSuccess(Identity id) throws IOException {
-                // logs this user in.
-                UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                        id.getEffectiveNick(), "", id.getGrantedAuthorities().toArray(new GrantedAuthority[id.getGrantedAuthorities().size()]));
-                SecurityContextHolder.getContext().setAuthentication(token);
-
-                // update the user profile.
-                User u = User.get(token.getName());
+                // Create the user if needed and update the profile.
+                User u = User.get(id.getEffectiveNick());
                 id.updateProfile(u);
                 OpenIdUserProperty p = u.getProperty(OpenIdUserProperty.class);
                 if(p != null)
                 	p.addIdentifier(id.getOpenId());
+
+                // Because of JENKINS-36709 we log this user in after getting it.
+                // so that we use the correct id.
+                UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                        u.getId(), "", id.getGrantedAuthorities().toArray(new GrantedAuthority[id.getGrantedAuthorities().size()]));
+                SecurityContextHolder.getContext().setAuthentication(token);
 
                 return new HttpRedirect(referer);
             }

--- a/src/test/java/hudson/plugins/openid/OpenIdSsoSecurityRealmTest.java
+++ b/src/test/java/hudson/plugins/openid/OpenIdSsoSecurityRealmTest.java
@@ -73,8 +73,6 @@ public class OpenIdSsoSecurityRealmTest extends OpenIdTestCase {
 
         assertNotNull(top.getAnchorByHref("/logout"));
 
-        assertNotNull(top.getAnchorByHref("/user/" + userName));
-
         Authentication a = wc.executeOnServer(new Callable<Authentication>() {
             public Authentication call() throws Exception {
                 return SecurityContextHolder.getContext().getAuthentication();
@@ -87,6 +85,7 @@ public class OpenIdSsoSecurityRealmTest extends OpenIdTestCase {
 
         User u = User.get(userName);
         assertNotNull(u);
+        assertNotNull(top.getAnchorByHref("/user/" + u.getId()));
         OpenIdUserProperty p = u.getProperty(OpenIdUserProperty.class);
         assertNotNull(p);
 


### PR DESCRIPTION
See [JENKINS-36709](https://issues.jenkins-ci.org/browse/JENKINS-36709)

Proposed fix is to "log the user in" after getting the actual `User` object, so that the correct id is used.

@reviewbybees 