### PR TITLE
Clear floats only for openid plugin elements

### DIFF
--- a/src/main/webapp/openid-prototype.js
+++ b/src/main/webapp/openid-prototype.js
@@ -45,17 +45,21 @@ var openid = {
 		$('openid_input_area').innerHTML = "";
 		var i = 0;
 		// add box for each provider
+		var html = '';
 		for (id in providers_large) {
-			box = this.getBoxHTML(id, providers_large[id], (this.all_small ? 'small' : 'large'), i++);
-			openid_btns.innerHTML += box;
-		}
-		if (providers_small) {
-			openid_btns.innerHTML += '<br/>';
-			for (id in providers_small) {
-				box = this.getBoxHTML(id, providers_small[id], 'small', i++);
-				openid_btns.innerHTML += box;
+			if (providers_large.hasOwnProperty(id)) {
+				html += this.getBoxHTML(id, providers_large[id], (this.all_small ? 'small' : 'large'), i++);
 			}
 		}
+		if (providers_small) {
+			html += '<br/>';
+			for (id in providers_small) {
+				if (providers_small.hasOwnProperty(id)) {
+					html += this.getBoxHTML(id, providers_small[id], 'small', i++);
+				}
+			}
+		}
+		openid_btns.innerHTML = html;
 		$('openid_form').onsubmit = this.onsubmit;
 		var box_id = this.readCookie();
 		if (box_id) {

--- a/src/main/webapp/openid-prototype.js
+++ b/src/main/webapp/openid-prototype.js
@@ -115,7 +115,7 @@ var openid = {
 	 * @return {Boolean}
 	 */
     submit : function() {
-      if (this.onsubmit())
+      if (openid.onsubmit())
         $('openid_form').submit();
     },
 

--- a/src/main/webapp/openid.css
+++ b/src/main/webapp/openid.css
@@ -18,12 +18,15 @@
 }
 
 #openid_input_area {
-	clear: both;
 	padding: 10px;
 }
 
-#openid_btns, #openid_btns br {
-	clear: both;
+#openid_btns {
+    overflow: hidden;
+}
+
+#openid_btns br {
+    clear: left;
 }
 
 #openid_highlight {


### PR DESCRIPTION
`clear: both` for `#openid_btns` is causing problems if page layout uses floats for laying out sections (i.e. sidebar). By adding `overflow: hidden` to `#openid_btn`, we create new formatting context so that `clear` property for its descendants is applied only to floats inside `#openid_btns` and not whole page.

src: http://www.phdcc.com/CSS_ClearingFloats.htm
