### PR TITLE
Jenkinsfile: Adjust the java version compatible with 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 11],
+  [platform: 'windows', jdk: 11],
+])


### PR DESCRIPTION
In order to pass the CI we need to bump the minimal java compatibility to 11